### PR TITLE
Updated Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,18 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
 
 env:
   - TYPO3_BRANCH=master COVERAGE=0
   - TYPO3_BRANCH=TYPO3_6-2 COVERAGE=0
 
 matrix:
-  allow_failures:
-    - env: TYPO3_BRANCH=master
+   allow_failures:
+      - env: TYPO3_BRANCH=master COVERAGE=0
+        php: 5.3
+      - env: TYPO3_BRANCH=master COVERAGE=0
+        php: 5.4
   include:
     - php: 5.5
       env: TYPO3_BRANCH=TYPO3_6-2 COVERAGE=1


### PR DESCRIPTION
Allow failure on PHP 5.3 & 5.4 on TYPO3 Master as TYPO3 7, requires minimum PHP 5.
