### PR TITLE
Fix of Warning: Illegal offset type in isset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
 
 before_script:
   # Installs TYPO3
-  - composer require typo3/cms=$TYPO3_VERSION;
+  - composer require typo3/cms=$TYPO3_VERSION --prefer-source;
   # Restore composer.json
   - git checkout composer.json;
   - export "TYPO3_PATH_WEB"=$PWD/.Build/Web;

--- a/Classes/LanguageRepository.php
+++ b/Classes/LanguageRepository.php
@@ -156,7 +156,8 @@ class LanguageRepository {
 		$cacheManager = CacheManager::getInstance();
 		$cacheData = $cacheManager->get('languagesCache');
 		$isCacheEnabled = $cacheManager->isCacheEnabled();
-
+		$id = is_array($id) ? array_shift($id) : $id;
+		
 		if (! $isCacheEnabled || ! isset($cacheData[$id])) {
 			if ($id == 0) {
 				$cacheData[$id] = $this->getDefaultLanguage();
@@ -166,7 +167,6 @@ class LanguageRepository {
 				$language = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('AOE\\Languagevisibility\\Language');
 
 				$language->setData($row);
-				$id = is_array($id) ? array_shift($id) : $id;
 				$cacheData[$id] = $language;
 				$GLOBALS['TYPO3_DB']->sql_free_result($res);
 


### PR DESCRIPTION
Even though it would be better to use PHP7.1 type hints and rely on $id that is always integer. I'd like to propose this change to fix php warning error of isset($cacheData[$id]), when $id is array. This change also fixes bug of intval($id) (line: 165), because intval of array is null and improves performance, because it won't try to get data again from database.