### PR TITLE
[Bug] Fixed reports compatibility with TYPO3 7

### DIFF
--- a/Classes/Language.php
+++ b/Classes/Language.php
@@ -92,7 +92,7 @@ class Language {
 	/**
 	 * Returns the fallback order for this language for elements
 	 *
-	 * @param tx_languagevisibility_element $contextElement
+	 * @param Element $contextElement
 	 * @return array
 	 */
 	public function getFallbackOrderElement(Element $contextElement) {
@@ -112,7 +112,7 @@ class Language {
 	/**
 	 * Returns the fallback order for news elements as array
 	 *
-	 * @param tx_languagevisibility_element $contextElement
+	 * @param Element $contextElement
 	 * @return array
 	 */
 	public function getFallbackOrderTTNewsElement(Element $contextElement) {
@@ -133,7 +133,7 @@ class Language {
 	 *
 	 * @param unknown_type $key
 	 * @param unknown_type $fallbackorder
-	 * @param tx_languagevisibility_element $contextElement
+	 * @param Element $contextElement
 	 * @return array
 	 */
 	protected function triggerFallbackHooks($key, $fallbackorder, Element $contextElement) {
@@ -170,7 +170,7 @@ class Language {
 	/**
 	 * Method to read the defaultVisibility setting of pages.
 	 *
-	 * @param tx_languagevisibility_element $contextElement
+	 * @param Element $contextElement
 	 * @return string
 	 */
 	public function getDefaultVisibilityForPage(Element $contextElement) {
@@ -180,7 +180,7 @@ class Language {
 	/**
 	 * Method to read the defaultVisibility for elements
 	 *
-	 * @param tx_languagevisibility_element $contextElement
+	 * @param Element $contextElement
 	 * @return string
 	 */
 	public function getDefaultVisibilityForElement(Element $contextElement) {

--- a/Classes/ReportsConfigurationStatus.php
+++ b/Classes/ReportsConfigurationStatus.php
@@ -92,7 +92,7 @@ class ReportsConfigurationStatus implements \TYPO3\CMS\Reports\StatusProviderInt
 			}
 		}
 
-		return GeneralUtility::makeInstance('TYPO3\CMS\Reports\Status'',
+		return GeneralUtility::makeInstance('TYPO3\CMS\Reports\Status',
 			'EXT:languagevisibility config.sys_language_mode',
 			$value,
 			$message,

--- a/Classes/ReportsConfigurationStatus.php
+++ b/Classes/ReportsConfigurationStatus.php
@@ -60,7 +60,7 @@ class ReportsConfigurationStatus implements \TYPO3\CMS\Reports\StatusProviderInt
 		$value = $GLOBALS['LANG']->sL('LLL:EXT:languagevisibility/locallang_db.xml:reports.ok.value');
 		$severity = \TYPO3\CMS\Reports\Status::OK;
 
-		$rootTpls = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecordsByField('sys_template', 'root', '1', '');
+		$rootTpls = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecordsByField('sys_template', 'root', '1', '', 'pid');
 
 		foreach ($rootTpls as $tpl) {
 			/**
@@ -71,7 +71,7 @@ class ReportsConfigurationStatus implements \TYPO3\CMS\Reports\StatusProviderInt
 			$tmpl->init();
 
 			// Gets the rootLine
-			$sys_page = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\Page\PageRepository');
+			$sys_page = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
 			$rootLine = $sys_page->getRootLine($tpl['pid']);
 			$tmpl->runThroughTemplates($rootLine, $tpl['uid']);
 
@@ -92,7 +92,7 @@ class ReportsConfigurationStatus implements \TYPO3\CMS\Reports\StatusProviderInt
 			}
 		}
 
-		return GeneralUtility::makeInstance('TYPO3\CMS\Reports\Status',
+		return GeneralUtility::makeInstance('TYPO3\\CMS\\Reports\\Status',
 			'EXT:languagevisibility config.sys_language_mode',
 			$value,
 			$message,

--- a/Classes/ReportsConfigurationStatus.php
+++ b/Classes/ReportsConfigurationStatus.php
@@ -58,9 +58,9 @@ class ReportsConfigurationStatus implements \TYPO3\CMS\Reports\StatusProviderInt
 			'fail' => array(),
 		);
 		$value = $GLOBALS['LANG']->sL('LLL:EXT:languagevisibility/locallang_db.xml:reports.ok.value');
-		$severity = tx_reports_reports_status_Status::OK;
+		$severity = \TYPO3\CMS\Reports\Status::OK;
 
-		$rootTpls = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecordsByField('sys_template', 'root', '1', '', 'pid');
+		$rootTpls = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecordsByField('sys_template', 'root', '1', '');
 
 		foreach ($rootTpls as $tpl) {
 			/**
@@ -70,8 +70,8 @@ class ReportsConfigurationStatus implements \TYPO3\CMS\Reports\StatusProviderInt
 			$tmpl->tt_track = 0;
 			$tmpl->init();
 
-				// Gets the rootLine
-			$sys_page = GeneralUtility::makeInstance('t3lib_pageSelect');
+			// Gets the rootLine
+			$sys_page = GeneralUtility::makeInstance('TYPO3\CMS\Frontend\Page\PageRepository');
 			$rootLine = $sys_page->getRootLine($tpl['pid']);
 			$tmpl->runThroughTemplates($rootLine, $tpl['uid']);
 
@@ -92,7 +92,7 @@ class ReportsConfigurationStatus implements \TYPO3\CMS\Reports\StatusProviderInt
 			}
 		}
 
-		return GeneralUtility::makeInstance('tx_reports_reports_status_Status',
+		return GeneralUtility::makeInstance('TYPO3\CMS\Reports\Status'',
 			'EXT:languagevisibility config.sys_language_mode',
 			$value,
 			$message,


### PR DESCRIPTION
Updated old TYPO3 6 classes and makes compatibility with Mysql 5.7+ 

The query (SELECT *  FROM sys_template WHERE root='1' AND sys_template.deleted=0  AND (sys_template.t3ver_state <= 0 OR sys_template.t3ver_wsid = 0) **GROUP BY pid**) won't work because of error "Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'gws.sys_template.uid' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by" (line 63)

$tpl requires only pid and uid, previous versions of mysql chose randomly/first uid when you grouped result by pid. It is not good.