### PR TITLE
[Bug] Renamed class T3libTcemain to T3libTceMain

### DIFF
--- a/Classes/Hooks/T3libTceMain.php
+++ b/Classes/Hooks/T3libTceMain.php
@@ -31,9 +31,9 @@ use AOE\Languagevisibility\Services\BeServices;
 use AOE\Languagevisibility\Services\VisibilityService;
 
 /**
- * Class T3LibTceMain
+ * Class T3libTceMain
  */
-class T3LibTceMain {
+class T3libTceMain {
 
 	/**
 	 * @param string $table

--- a/Classes/Hooks/T3libTceMain.php
+++ b/Classes/Hooks/T3libTceMain.php
@@ -31,9 +31,9 @@ use AOE\Languagevisibility\Services\BeServices;
 use AOE\Languagevisibility\Services\VisibilityService;
 
 /**
- * Class tx_languagevisibility_hooks_t3lib_tcemain
+ * Class T3LibTceMain
  */
-class T3libTcemain {
+class T3LibTceMain {
 
 	/**
 	 * @param string $table

--- a/Classes/LanguageRepository.php
+++ b/Classes/LanguageRepository.php
@@ -156,7 +156,8 @@ class LanguageRepository {
 		$cacheManager = CacheManager::getInstance();
 		$cacheData = $cacheManager->get('languagesCache');
 		$isCacheEnabled = $cacheManager->isCacheEnabled();
-
+		$id = is_array($id) ? array_shift($id) : $id;
+		
 		if (! $isCacheEnabled || ! isset($cacheData[$id])) {
 			if ($id == 0) {
 				$cacheData[$id] = $this->getDefaultLanguage();
@@ -166,7 +167,6 @@ class LanguageRepository {
 				$language = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('AOE\\Languagevisibility\\Language');
 
 				$language->setData($row);
-				$id = is_array($id) ? array_shift($id) : $id;
 				$cacheData[$id] = $language;
 				$GLOBALS['TYPO3_DB']->sql_free_result($res);
 


### PR DESCRIPTION
It was misconfiguration and problem with calling hook because php7 is case sensitive. Ext_localconf.php called T3LibTceMain, but class was named T3LibTcemain. I prefer to use T3LibTceMain, therefore I renamed filename and classname to T3LibTceMain