### PR TITLE
Changed database table default value for text field

### DIFF
--- a/Classes/LanguageRepository.php
+++ b/Classes/LanguageRepository.php
@@ -156,7 +156,8 @@ class LanguageRepository {
 		$cacheManager = CacheManager::getInstance();
 		$cacheData = $cacheManager->get('languagesCache');
 		$isCacheEnabled = $cacheManager->isCacheEnabled();
-
+		$id = is_array($id) ? array_shift($id) : $id;
+		
 		if (! $isCacheEnabled || ! isset($cacheData[$id])) {
 			if ($id == 0) {
 				$cacheData[$id] = $this->getDefaultLanguage();
@@ -166,7 +167,6 @@ class LanguageRepository {
 				$language = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('AOE\\Languagevisibility\\Language');
 
 				$language->setData($row);
-				$id = is_array($id) ? array_shift($id) : $id;
 				$cacheData[$id] = $language;
 				$GLOBALS['TYPO3_DB']->sql_free_result($res);
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE sys_language (
 # Table structure for table 'pages'
 #
 CREATE TABLE pages (
-	tx_languagevisibility_visibility text NOT NULL,
+	tx_languagevisibility_visibility text NULL,
 	tx_languagevisibility_inheritanceflag_original tinyint(1) DEFAULT '0' NOT NULL,
 	tx_languagevisibility_inheritanceflag_overlayed tinyint(1) DEFAULT '0' NOT NULL
 );

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE sys_language (
 # Table structure for table 'pages'
 #
 CREATE TABLE pages (
-	tx_languagevisibility_visibility text NULL,
+	tx_languagevisibility_visibility text,
 	tx_languagevisibility_inheritanceflag_original tinyint(1) DEFAULT '0' NOT NULL,
 	tx_languagevisibility_inheritanceflag_overlayed tinyint(1) DEFAULT '0' NOT NULL
 );
@@ -24,7 +24,7 @@ CREATE TABLE pages (
 # Table structure for table 'pages_language_overlay'
 #
 CREATE TABLE pages_language_overlay (
-	tx_languagevisibility_visibility text NOT NULL,
+	tx_languagevisibility_visibility text,
 	tx_languagevisibility_inheritanceflag_original tinyint(1) DEFAULT '0' NOT NULL,
 	tx_languagevisibility_inheritanceflag_overlayed tinyint(1) DEFAULT '0' NOT NULL
 );
@@ -33,14 +33,14 @@ CREATE TABLE pages_language_overlay (
 # Table structure for table 'tt_content'
 #
 CREATE TABLE tt_content (
-	tx_languagevisibility_visibility text NOT NULL
+	tx_languagevisibility_visibility text
 );
 
 #
 # Table structure for table 'tt_news'
 #
 CREATE TABLE tt_news (
-	tx_languagevisibility_visibility text NOT NULL
+	tx_languagevisibility_visibility text
 );
 
 #


### PR DESCRIPTION
This change is related again to mysql 5.7+. Mysql doesn't support default values for TEXT fields. There is only allowed default value NULL. Mysql 5.7 removes all magic and rely strictly on configuration, which is good I think. Mysql 5.6 allows to INSERT empty string for NOT NULL text fields, but Mysql 5.7 not.

This change fixes bug regarding creating new page.

Again I think it is desired to allow setting NULL for optional columns. It will decrease overall size of data on disk, because NULL equals to 0 bytes and empty string 2 bytes